### PR TITLE
POR-2605 enable timesheets contract year view from Contracts page

### DIFF
--- a/models/contract.js
+++ b/models/contract.js
@@ -29,6 +29,7 @@ class Contract {
     this.setOptionalAttribute(data, 'status');
     this.setOptionalAttribute(data, 'description');
     this.setOptionalAttribute(data, 'directorate');
+    this.setOptionalAttribute(data, 'contractViewEnabled');
   } // constructor
 
   /**

--- a/routes/timesheetsRoutes.js
+++ b/routes/timesheetsRoutes.js
@@ -247,7 +247,7 @@ class TimesheetsRoutes {
   _getCurrentProject(employee) {
     let currentProject = null;
     _.forEach(employee.contracts, (c) => {
-      let project = _.find(c.projects, (p) => p.bonusCalculationDate);
+      let project = _.find(c.projects, (p) => !p.endDate);
       if (project) currentProject = _.cloneDeep(project);
     });
     return currentProject;


### PR DESCRIPTION
Ticket Link: [https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?selectedIssue=POR-2605]
Admins can now enable the Contract Year View button on the timesheets widget for employees by activating the toggle on a Contracts settings modal