### PR TITLE
POR-2626: allow admins to set timesheets contract year view from different settings

### DIFF
--- a/models/contract.js
+++ b/models/contract.js
@@ -13,6 +13,7 @@ const _ = require('lodash');
  * - status
  * - description
  * - directorate
+ * - settings
  */
 
 class Contract {
@@ -29,7 +30,7 @@ class Contract {
     this.setOptionalAttribute(data, 'status');
     this.setOptionalAttribute(data, 'description');
     this.setOptionalAttribute(data, 'directorate');
-    this.setOptionalAttribute(data, 'contractViewEnabled');
+    this.setOptionalAttribute(data, 'settings');
   } // constructor
 
   /**


### PR DESCRIPTION
Ticket link: [https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?selectedIssue=POR-2626]
Change the Contract settings view to allow admins to set timesheets contract year view based on PoP start date