### PR TITLE
POR-2658 Allow admins to reject expenses

### DIFF
--- a/models/expense.js
+++ b/models/expense.js
@@ -18,6 +18,7 @@ const _ = require('lodash');
  * - recipient
  * - reimbursedDate
  * - receipt
+ * - rejections
  * - note
  * - url
  * - canDelete
@@ -38,6 +39,7 @@ class Expense {
     this.setOptionalAttribute(data, 'recipient');
     this.setOptionalAttribute(data, 'reimbursedDate');
     this.setOptionalAttribute(data, 'receipt');
+    this.setOptionalAttribute(data, 'rejections');
     this.setOptionalAttribute(data, 'note');
     this.setOptionalAttribute(data, 'url');
     this.setOptionalAttribute(data, 'canDelete');

--- a/routes/crudRoutes.js
+++ b/routes/crudRoutes.js
@@ -932,7 +932,7 @@ class Crud {
     try {
       if (this._checkPermissionToUpdate(req.employee)) {
         // employee has permission to update table
-        let objectUpdated = await this._update(req.body); // update object
+        let objectUpdated = await this._update(req); // update object
         let objectValidated = await this._validateInputs(objectUpdated); // validate inputs
         let dataUpdated;
         // add object to database

--- a/spec/routes/crudRoutes.spec.js
+++ b/spec/routes/crudRoutes.spec.js
@@ -1817,7 +1817,7 @@ describe('crudRoutes', () => {
         it('should respond with a 200 and data', (done) => {
           crudRoutes._updateWrapper(req, res).then((data) => {
             expect(data).toEqual(trainingUrl);
-            expect(crudRoutes._update).toHaveBeenCalledWith(trainingUrl);
+            expect(crudRoutes._update).toHaveBeenCalledWith(req);
             expect(databaseModify.updateEntryInDB).toHaveBeenCalledWith(trainingUrl);
             expect(res.status).toHaveBeenCalledWith(200);
             expect(res.send).toHaveBeenCalledWith(trainingUrl);
@@ -1835,7 +1835,7 @@ describe('crudRoutes', () => {
         it('should respond with a 200 and data', (done) => {
           crudRoutes._updateWrapper(req, res).then((data) => {
             expect(data).toEqual(BODY_DATA);
-            expect(crudRoutes._update).toHaveBeenCalledWith(BODY_DATA);
+            expect(crudRoutes._update).toHaveBeenCalledWith(req);
             expect(databaseModify.updateEntryInDB).toHaveBeenCalledWith(BODY_DATA);
             expect(res.status).toHaveBeenCalledWith(200);
             expect(res.send).toHaveBeenCalledWith(BODY_DATA);
@@ -1857,7 +1857,7 @@ describe('crudRoutes', () => {
         it('should respond with a 200 and data', (done) => {
           crudRoutes._updateWrapper(req, res).then((data) => {
             expect(data).toEqual(newObject);
-            expect(crudRoutes._update).toHaveBeenCalledWith(BODY_DATA);
+            expect(crudRoutes._update).toHaveBeenCalledWith(req);
             expect(res.status).toHaveBeenCalledWith(200);
             expect(res.send).toHaveBeenCalledWith(newObject);
             done();
@@ -1902,7 +1902,7 @@ describe('crudRoutes', () => {
       it('should respond with a 403 and error', (done) => {
         crudRoutes._updateWrapper(req, res).then((data) => {
           expect(data).toEqual(err);
-          expect(crudRoutes._update).toHaveBeenCalledWith(BODY_DATA);
+          expect(crudRoutes._update).toHaveBeenCalledWith(req);
           expect(res.status).toHaveBeenCalledWith(403);
           expect(res.send).toHaveBeenCalledWith(err);
           done();
@@ -1926,7 +1926,7 @@ describe('crudRoutes', () => {
       it('should respond with a 403 and error', (done) => {
         crudRoutes._updateWrapper(req, res).then((data) => {
           expect(data).toEqual(err);
-          expect(crudRoutes._update).toHaveBeenCalledWith(BODY_DATA);
+          expect(crudRoutes._update).toHaveBeenCalledWith(req);
           expect(crudRoutes._validateInputs).toHaveBeenCalledWith(BODY_DATA);
           expect(res.status).toHaveBeenCalledWith(403);
           expect(res.send).toHaveBeenCalledWith(err);
@@ -1951,7 +1951,7 @@ describe('crudRoutes', () => {
       it('should respond with a 403 and error', (done) => {
         crudRoutes._updateWrapper(req, res).then((data) => {
           expect(data).toEqual(err);
-          expect(crudRoutes._update).toHaveBeenCalledWith(BODY_DATA);
+          expect(crudRoutes._update).toHaveBeenCalledWith(req);
           expect(databaseModify.updateEntryInDB).toHaveBeenCalledWith(BODY_DATA);
           expect(res.status).toHaveBeenCalledWith(403);
           expect(res.send).toHaveBeenCalledWith(err);

--- a/spec/routes/expenseRoutes.spec.js
+++ b/spec/routes/expenseRoutes.spec.js
@@ -1625,7 +1625,7 @@ describe('expenseRoutes', () => {
 
       it('should return a 404 rejected promise', (done) => {
         expenseRoutes
-          ._update(newExpenseData)
+          ._update({ body: newExpenseData })
           .then(() => {
             fail('expected error to have been thrown');
             done();
@@ -1651,7 +1651,7 @@ describe('expenseRoutes', () => {
 
       it('should return a 404 rejected promise', (done) => {
         expenseRoutes
-          ._update(newExpenseData)
+          ._update({ body: newExpenseData })
           .then(() => {
             fail('expected error to have been thrown');
             done();
@@ -1678,7 +1678,7 @@ describe('expenseRoutes', () => {
 
       it('should return a 404 rejected promise', (done) => {
         expenseRoutes
-          ._update(newExpenseData)
+          ._update({ body: newExpenseData })
           .then(() => {
             fail('expected error to have been thrown');
             done();
@@ -1706,7 +1706,7 @@ describe('expenseRoutes', () => {
           });
 
           it('should return the expense updated and update budgets', (done) => {
-            expenseRoutes._update(newExpenseData).then((data) => {
+            expenseRoutes._update({ body: newExpenseData }).then((data) => {
               expect(data).toEqual(newExpense);
               expect(databaseModify.getEntry).toHaveBeenCalledWith(newExpenseData.id);
               expect(employeeDynamo.getEntry).toHaveBeenCalledWith(newExpense.employeeId);
@@ -1735,7 +1735,7 @@ describe('expenseRoutes', () => {
 
           it('should return a 403 rejected promise', (done) => {
             expenseRoutes
-              ._update(newExpenseData)
+              ._update({ body: newExpenseData })
               .then(() => {
                 fail('expected error to have been thrown');
                 done();
@@ -1763,7 +1763,7 @@ describe('expenseRoutes', () => {
 
           it('should return a 404 rejected promise', (done) => {
             expenseRoutes
-              ._update(newExpenseData)
+              ._update({ body: newExpenseData })
               .then(() => {
                 fail('expected error to have been thrown');
                 done();
@@ -1793,7 +1793,7 @@ describe('expenseRoutes', () => {
           });
 
           it('should return the expense updated and update budgets', (done) => {
-            expenseRoutes._update(newExpenseData).then((data) => {
+            expenseRoutes._update({ body: newExpenseData }).then((data) => {
               expect(data).toEqual(newExpense);
               expect(expenseRoutes._validateExpense).toHaveBeenCalled();
               expect(expenseRoutes._validateExpense).toHaveBeenCalled();
@@ -1850,7 +1850,7 @@ describe('expenseRoutes', () => {
               });
 
               it('should create a new expense and delete the old', (done) => {
-                expenseRoutes._update(newExpenseData).then((data) => {
+                expenseRoutes._update({ body: newExpenseData }).then((data) => {
                   expect(data).toEqual(newExpense);
                   expect(expenseRoutes._changeBucket).toHaveBeenCalledWith(
                     oldExpense.employeeId,
@@ -1879,7 +1879,7 @@ describe('expenseRoutes', () => {
               });
 
               it('should create a new expense and delete the old', (done) => {
-                expenseRoutes._update(newExpenseData).then((data) => {
+                expenseRoutes._update({ body: newExpenseData }).then((data) => {
                   expect(data).toEqual(newExpense);
                   expect(expenseRoutes._changeBucket).toHaveBeenCalledWith(
                     oldExpense.employeeId,
@@ -1914,7 +1914,7 @@ describe('expenseRoutes', () => {
               });
 
               it('should create a new expense and delete the old', (done) => {
-                expenseRoutes._update(newExpenseData).then((data) => {
+                expenseRoutes._update({ body: newExpenseData }).then((data) => {
                   expect(data).toEqual(newExpense);
                   expect(expenseRoutes._changeBucket).toHaveBeenCalledTimes(0);
                   expect(expenseRoutes._create).toHaveBeenCalledWith(newExpense);
@@ -1940,7 +1940,7 @@ describe('expenseRoutes', () => {
               });
 
               it('should create a new expense and delete the old', (done) => {
-                expenseRoutes._update(newExpenseData).then((data) => {
+                expenseRoutes._update({ body: newExpenseData }).then((data) => {
                   expect(data).toEqual(newExpense);
                   expect(expenseRoutes._changeBucket).toHaveBeenCalledTimes(0);
                   expect(expenseRoutes._create).toHaveBeenCalledWith(newExpense);
@@ -1974,7 +1974,7 @@ describe('expenseRoutes', () => {
             });
 
             it('should create a new expense and delete the old', (done) => {
-              expenseRoutes._update(newExpenseData).then((data) => {
+              expenseRoutes._update({ body: newExpenseData }).then((data) => {
                 expect(data).toEqual(newExpense);
                 expect(expenseRoutes._changeBucket).toHaveBeenCalledTimes(0);
                 expect(expenseRoutes._create).toHaveBeenCalledWith(newExpense);
@@ -1994,7 +1994,7 @@ describe('expenseRoutes', () => {
             });
 
             it('should create a new expense and delete the old', (done) => {
-              expenseRoutes._update(newExpenseData).then((data) => {
+              expenseRoutes._update({ body: newExpenseData }).then((data) => {
                 expect(data).toEqual(newExpense);
                 expect(expenseRoutes._changeBucket).toHaveBeenCalledTimes(0);
                 expect(expenseRoutes._create).toHaveBeenCalledWith(newExpense);
@@ -2030,7 +2030,7 @@ describe('expenseRoutes', () => {
 
           it('should return a 404 rejected promise', (done) => {
             expenseRoutes
-              ._update(newExpenseData)
+              ._update({ body: newExpenseData })
               .then(() => {
                 fail('expected error to have been thrown');
                 done();
@@ -2057,7 +2057,7 @@ describe('expenseRoutes', () => {
 
           it('should return a 403 rejected promise', (done) => {
             expenseRoutes
-              ._update(newExpenseData)
+              ._update({ body: newExpenseData })
               .then(() => {
                 fail('expected error to have been thrown');
                 done();
@@ -2086,7 +2086,7 @@ describe('expenseRoutes', () => {
 
           it('should return a 404 rejected promise', (done) => {
             expenseRoutes
-              ._update(newExpenseData)
+              ._update({ body: newExpenseData })
               .then(() => {
                 fail('expected error to have been thrown');
                 done();
@@ -2117,7 +2117,7 @@ describe('expenseRoutes', () => {
 
           it('should return a 404 rejected promise', (done) => {
             expenseRoutes
-              ._update(newExpenseData)
+              ._update({ body: newExpenseData })
               .then(() => {
                 fail('expected error to have been thrown');
                 done();
@@ -2150,7 +2150,7 @@ describe('expenseRoutes', () => {
 
           it('should return a 404 rejected promise', (done) => {
             expenseRoutes
-              ._update(newExpenseData)
+              ._update({ body: newExpenseData })
               .then(() => {
                 fail('expected error to have been thrown');
                 done();


### PR DESCRIPTION
Ticket link: [https://consultwithcase.atlassian.net/jira/software/c/projects/POR/boards/7?selectedIssue=POR-2658]

Admins can now hard or soft reject expenses. Hard rejections are uneditable and undeletable by the user, soft rejections are requests for revisions before the expense can be reimbursed. Both rejection types will email the user with a reason for rejection.