### PR TITLE
POR-3111 PTO Planner bugs out for 'user' role

### DIFF
--- a/routes/crudRoutes.js
+++ b/routes/crudRoutes.js
@@ -304,7 +304,7 @@ class Crud {
       `Checking if employee ${employee.id} has permission to read all entries from the ${this._getTableName()} table`
     );
     // compute method
-    let userPermissions = isUser(employee) && this._checkTableName(['employees', 'training-urls', 'contracts']);
+    let userPermissions = isUser(employee) && this._checkTableName(['employees', 'training-urls', 'contracts', 'tags']);
     let adminPermissions =
       isAdmin(employee) &&
       this._checkTableName([


### PR DESCRIPTION
Employees without elevated roles (basically everyone) weren't able to access the PTO planner due to permissions on tags. This allows users to get **their own benefit plan** tag, but nothing else. Ensure that users cannot see any more data than that.