### PR TITLE
POR 3124 - Allowing timesheets widget to go back further than just 1 month

### DIFF
--- a/routes/timesheetsRoutes.js
+++ b/routes/timesheetsRoutes.js
@@ -67,6 +67,10 @@ class TimesheetsRoutes {
       // mysterio function parameters
       let payload = { employeeNumber, ...(isCyk && { legacyADP: true, aoid: employee[cykAoidKey] }) };
 
+      
+      let  currentDate = new Date();
+      let numMonths = currentDate.getMonth();
+
       switch (code) {
         case 1:
           // only PTO data requested
@@ -74,7 +78,12 @@ class TimesheetsRoutes {
           break;
         case 2:
           // current and previous pay period timesheets
-          payload.periods = this._getMonthlyPayPeriods(2);
+          if(numMonths < 1) {
+            numMonths += 2;
+          } else {
+            numMonths++;
+          }
+          payload.periods = this._getMonthlyPayPeriods(numMonths);
           break;
         default:
           // timesheets that fall within the requested start and end dates


### PR DESCRIPTION
Ticket link: [POR 3124](https://consultwithcase.atlassian.net/browse/POR-3124)
Allow timesheets widget to go back to previous months from January to current month.